### PR TITLE
Import scheme out of cond-expand

### DIFF
--- a/iconv.scm
+++ b/iconv.scm
@@ -15,11 +15,12 @@
 (module iconv
   (make-iconv)
 
+(import scheme)
 (cond-expand
     (chicken-4
-     (import scheme chicken extras foreign))
+     (import chicken extras foreign))
     (chicken-5
-     (import scheme (chicken base) (chicken foreign) (chicken gc)))
+     (import (chicken base) (chicken foreign) (chicken gc)))
     (else (error "Unsupported chicken version.")))
 
 (declare (foreign-declare "#include <iconv.h>\n#include <errno.h>\n"))


### PR DESCRIPTION
In CHICKEN 4 cond-expand needs the scheme module, so import it in the
module toplevel.

Fixes

```
Syntax error (import): cannot import from undefined module

        base
```

in the installation of iconv with CHICKEN 4.